### PR TITLE
Add extra checks to the source object

### DIFF
--- a/src/exports/Image/index.js
+++ b/src/exports/Image/index.js
@@ -40,7 +40,7 @@ const resolveAssetDimensions = source => {
   if (typeof source === 'number') {
     const { height, width } = getAssetByID(source);
     return { height, width };
-  } else if (typeof source === 'object') {
+  } else if (source != null && !Array.isArray(source) && typeof source === 'object') {
     const { height, width } = source;
     return { height, width };
   }


### PR DESCRIPTION
Checks for a non-null and a non-array `source` before accessing `height` and `width`.

See original repo: https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/Image/index.js#L95